### PR TITLE
Switch \# to '#' in regex.

### DIFF
--- a/lib/Lingua/Number.pm
+++ b/lib/Lingua/Number.pm
@@ -142,7 +142,7 @@ sub rule2text (Str $lingua, Str $ruletype, $number) is export {
 		$func ||= $ruletype;
 		
 
-		if $func ~~ /^\#/ {
+		if $func ~~ /^'#'/ {
 			@items.push: format_digital($func, $lingua, $number);
 		}
 		else {


### PR DESCRIPTION
This gets Lingua::Number up and running again with the latest Rakudo.
