### PR TITLE
Add unit declarator to module declarations

### DIFF
--- a/lib/Lingua/Number.pm
+++ b/lib/Lingua/Number.pm
@@ -1,5 +1,5 @@
 use v6;
-module Lingua::Number;
+unit module Lingua::Number;
 
 use XML;
 use JSON::Tiny;


### PR DESCRIPTION
As of Rakudo 2015.05, the `unit` declarator is required before using
`module`, `class` or `grammar` declarations (unless it uses a block).  Code
still using the old blockless semicolon form will throw a warning. This
commit stops the warning from appearing in the new Rakudo.